### PR TITLE
Fftvectorized

### DIFF
--- a/R/project_methods.R
+++ b/R/project_methods.R
@@ -43,60 +43,35 @@ setMethod('getPhiPrey', signature(object='MizerParams', n = 'matrix', n_pp='nume
 	    stop("n does not have the right number of size groups (second dimension)")
 	if(length(n_pp) != length(object@w_full))
 	    stop("n_pp does not have the right number of size groups")
-	# n_eff_prey is the total prey abundance by size exposed to each predator (prey
-	# not broken into species - here we are just working out how much a predator
-	# eats - not which species are being eaten - that is in the mortality calculation
-###    n_eff_prey <- sweep(object@interaction %*% n, 2, object@w * object@dw, "*", check.margin=FALSE) 
-	# Quick reference to just the fish part of the size spectrum
+
+	# The constant step size in log size
+	dx <- log(object@w[2]/object@w[1])  
+
+	# The object@w vector only gives weights from the egg size up to the max fish size. 
+	# However object@w_full gives more smaller weights and idx_sp are the index 
+	# values of object@w_full such that (object@w_full)[idx_sp]=object@w
 	idx_sp <- (length(object@w_full) - length(object@w) + 1):length(object@w_full)
-	# pred_kernel is predator x predator size x prey size
-	# So multiply 3rd dimension of pred_kernel by the prey abundance
-	# Then sum over 3rd dimension to get total eaten by each predator by predator size
-    # This line is a bottle neck
-###	phi_prey_species <- rowSums(sweep(object@pred_kernel[,,idx_sp,drop=FALSE],c(1,3),n_eff_prey,"*", check.margin=FALSE),dims=2)
-	# Eating the background
-    # This line is a bottle neck
-###	phi_prey_background <- rowSums(sweep(object@pred_kernel,3,object@dw_full*object@w_full*n_pp,"*", check.margin=FALSE),dims=2)
-    # get egg size
-	w0 <- object@w[1]
-	# get feeding kernel parameters
-	Beta <- log(object@species_params$beta)
-	sigma <- object@species_params$sigma
-	# get full vector of weight values (including small weights, below egg-size, for resource-energy description)
-	wFull <- object@w_full
-	# take logs 
-	xFull <- log(wFull)
-	# xFull is the mass vector, in log space, it describes weights down to the plankton, and up to the largest fish,
-	# The entries of xFull are evenly spaced, and translating xFull (i.e., adding a constant to each entry) should not alter
-	# the result to getPhi, so we translate our xFull so it begins with zero.
-	xFull <- xFull - xFull[1]
-	# The constant difference between the entries of xFull is dx
-	dx <- xFull[2]-xFull[1]
-	# The object@w vector only gives weights from the egg size up to the max fish size. However object@w_full gives more
-	# smaller weights and idx_sp are the index values of object@w_full such that (object@w_full)[idx_sp]=object@w
-	idx_sp <- (length(object@w_full) - length(object@w) + 1):length(object@w_full)
-	# Our output, fullEnergyMat, will be a ((# species) times length(wFull)) matrix, initially filled with 0's
-	fullEnergyMat <- matrix(0, nrow = dim(n)[1], ncol=length(object@w))
-	# In the calculation we use the length length(wFull) vector, fishEaten, which we initially fill with 0's
-	fishEaten <- rep(0, length.out = length(wFull))
-	
-	for(i in 1:(dim(n)[1])) {
-	# Looking at Equation (3.4), for available energy in the mizer vignette, we have, for our predator species i, that
-	# fishEaten[k] equals the sum over all species j of fish, of theta_{i,j}*N_j(wFull[k])        
-	  fishEaten[idx_sp] <- (object@interaction %*% n)[i, ]
-	# The vector f2 equals everything inside integral (3.4), except the feeding kernel, phi_i(w_p/w). We work in log-space
-	# so an extra multiplier w_p is introduced. Eq (3.4) is then a convolution integral in terms of f2[w_p] and phi[w_p/w]
-	  f2 <- wFull*wFull*(n_pp + fishEaten)
-	# object@smat is a ((# species) times (length(wFull))) matrix where object@smat[i,k]=phi_i(exp(-xFull[k])) 
-	# In other words object@smat[i, ]=exp(-(xFull - Beta[i])^2/(2*sigma[i]^2)), we added smat to MizerParams-class.R
-	# Using spectral methods we can evaluate the integral as follow (here fft is the fast fourier transform).
-	# To save having to do an fft of smat every time step, we define fsmat such that fsmat[i, ] = fft(smat[i, ])  
-	  fullEnergy <- dx*Re(fft(object@fsmat[i, ]*fft(f2), inverse=TRUE)/length(object@smat[i,]))
-	# The result of this integral is one row of the matrix ((# species) times (length(wFull))), fullEnergyMat, outputted
-	  fullEnergyMat[i,] <- fullEnergy[idx_sp]
-	# Here fullEnergyMat[i,k] = E_{a.i}(wFull[k])
-	}
-		return(fullEnergyMat)
+
+	fishEaten <- matrix(0, nrow = dim(n)[1], ncol=length(object@w_full))
+	# Looking at Equation (3.4), for available energy in the mizer vignette, 
+	# we have, for our predator species i, that fishEaten[k] equals 
+	# the sum over all species j of fish, of theta_{i,j}*N_j(wFull[k])        
+	fishEaten[, idx_sp] <- object@interaction %*% n
+	# The vector f2 equals everything inside integral (3.4), except the feeding 
+	# kernel, phi_i(w_p/w). We work in log-space so an extra multiplier w_p is introduced.
+	f2 <- sweep(n_pp + fishEaten, 2, object@w_full*object@w_full, "*")
+	# Eq (3.4) is then a convolution integral in terms of f2[w_p] and phi[w_p/w].
+	# We approximate the integral by the trapezoidal method. Using the
+	# convolution theorem we can evaluate the resulting sum via fast fourier
+	# transform.
+	# The feeding kernel is in object@smat[i,k]=phi_i(exp(-xFull[k])) 
+	# and object@fsmat contains its Fourier transform.
+	# mvfft() does a Fourier transform of each column of its argument, but
+	# we need the Fourier transforms of each row, so we need to apply mvfft()
+	# to the transposed matrices and then transpose again at the end.
+	fullEnergy <- dx*Re(t(mvfft(mvfft(t(object@fsmat)) * mvfft(t(f2)), inverse=TRUE)))/length(object@w_full)
+
+	return(fullEnergy[, idx_sp, drop=FALSE])
 })
 
 

--- a/R/project_methods.R
+++ b/R/project_methods.R
@@ -59,7 +59,7 @@ setMethod('getPhiPrey', signature(object='MizerParams', n = 'matrix', n_pp='nume
 	fishEaten[, idx_sp] <- object@interaction %*% n
 	# The vector f2 equals everything inside integral (3.4), except the feeding 
 	# kernel, phi_i(w_p/w). We work in log-space so an extra multiplier w_p is introduced.
-	f2 <- sweep(n_pp + fishEaten, 2, object@w_full*object@w_full, "*")
+	f2 <- sweep(sweep(fishEaten, 2, n_pp, "+"), 2, object@w_full^2, "*")
 	# Eq (3.4) is then a convolution integral in terms of f2[w_p] and phi[w_p/w].
 	# We approximate the integral by the trapezoidal method. Using the
 	# convolution theorem we can evaluate the resulting sum via fast fourier
@@ -69,7 +69,7 @@ setMethod('getPhiPrey', signature(object='MizerParams', n = 'matrix', n_pp='nume
 	# mvfft() does a Fourier transform of each column of its argument, but
 	# we need the Fourier transforms of each row, so we need to apply mvfft()
 	# to the transposed matrices and then transpose again at the end.
-	fullEnergy <- dx*Re(t(mvfft(mvfft(t(object@fsmat)) * mvfft(t(f2)), inverse=TRUE)))/length(object@w_full)
+	fullEnergy <- dx*Re(t(mvfft(t(object@fsmat) * mvfft(t(f2)), inverse=TRUE)))/length(object@w_full)
 
 	return(fullEnergy[, idx_sp, drop=FALSE])
 })


### PR DESCRIPTION
Hi Richard, 

I removed the loop in getPhiPrey by using sweep() and mvfft(). This is more in line with the mizer coding style and also runs almost twice as fast (in the example of the north-sea model the new code takes 520 microseconds where the old code took 890 microseconds).

Feel free to merge this pull request.
